### PR TITLE
chore: change repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# opossum.lib.py
+# opossum-file
 
 [![REUSE status](https://api.reuse.software/badge/git.fsfe.org/reuse/api)](https://api.reuse.software/info/git.fsfe.org/reuse/api)
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/opossum-tool/opossum.lib.py)](https://github.com/opossum-tool/opossum.lib.py/releases/latest)
-![Lint and test](https://github.com/opossum-tool/opossum.lib.py/actions/workflows/lint_and_run_tests.yml/badge.svg)
-![build workflow](https://github.com/opossum-tool/opossum.lib.py/actions/workflows/build-and-e2e-test.yml/badge.svg)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/opossum-tool/opossum-file)](https://github.com/opossum-tool/opossum-file/releases/latest)
+![Lint and test](https://github.com/opossum-tool/opossum-file/actions/workflows/lint_and_run_tests.yml/badge.svg)
+![build workflow](https://github.com/opossum-tool/opossum-file/actions/workflows/build-and-e2e-test.yml/badge.svg)
 
-This is a library to convert an SPDX document to a file readable by [OpossumUI](https://github.com/opossum-tool/OpossumUI/).
+This is a library implementing operations around files readable by [OpossumUI](https://github.com/opossum-tool/OpossumUI/).
+Currently only supports conversion from single SPDX files to `.opossum` format.
 
 # Current state
 
@@ -98,7 +99,7 @@ This will create a self-contained executable file `dist/opossum-file` (`dist/opo
 
 Note: You will need the "maintain" role in order to create a new release.
 
-1. Go to the [GitHub releases page](https://github.com/opossum-tool/opossum.lib.py/releases/new) and use the UI to create a new release.
+1. Go to the [GitHub releases page](https://github.com/opossum-tool/opossum-file/releases/new) and use the UI to create a new release.
 2. The tag should have the format "opossum-file-$YEAR-$MONTH-$DAY" (in case of an Nth release on the same day "opossum-file-$YEAR-$MONTH-$DAY.N").
 3. The title of the release equals the tag.
 4. Click the button "Generate release notes" to get the description for the release. Then, remove all the contributions from @renovate which are just dependency upgrades.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 [project]
-name = "opossum.lib.py"
+name = "opossum-file"
 version = "0.1"
-description = "A library for handling Opossum files with Python"
+description = "A cli tool for handling Opossum files"
 requires-python = ">=3.13,<4"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.urls]
-Repository = "https://github.com/opossum-tool/opossum.lib.py"
+Repository = "https://github.com/opossum-tool/opossum-file"
 
 [project.scripts]
 opossum-file = "opossum_lib.cli:opossum_file"

--- a/uv.lock
+++ b/uv.lock
@@ -174,7 +174,7 @@ wheels = [
 ]
 
 [[package]]
-name = "opossum-lib-py"
+name = "opossum-file"
 version = "0.1"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
### Summary of changes

Renames the project in the readme and pyproject.toml

### Context and reason for change

As discussed with @mstykow and @Hellgartner, we change the scope of this project to be a more general tool around Opossum files. To this end, the repository will be renamed to `opossum-file`. This PR should be merged directly after the repo is renamed on GitHub.

This PR should be merged after #164 as it's based on that. Merging #165 before this as well is likely easier due to a merge conflict in `pyproject.toml`.