### PR TITLE
feat: change SPDX to the new internal opossum_model

### DIFF
--- a/src/opossum_lib/spdx/attribution_generation.py
+++ b/src/opossum_lib/spdx/attribution_generation.py
@@ -12,7 +12,7 @@ from spdx_tools.spdx.writer.tagvalue.file_writer import write_file
 from spdx_tools.spdx.writer.tagvalue.package_writer import write_package
 from spdx_tools.spdx.writer.tagvalue.snippet_writer import write_snippet
 
-from opossum_lib.opossum.opossum_file import OpossumPackage, SourceInfo
+from opossum_lib.opossum_model import OpossumPackage, SourceInfo
 from opossum_lib.spdx.constants import (
     PURL,
     SPDX_FILE_IDENTIFIER,
@@ -37,7 +37,7 @@ def create_package_attribution(package: Package) -> OpossumPackage:
         package_name=package.name,
         url=str(package.download_location),
         package_version=package.version,
-        package_p_u_r_l_appendix=_get_purl(package),
+        package_purl_appendix=_get_purl(package),
         copyright=str(package.copyright_text),
         comment=package_data.getvalue(),
         license_name=str(package.license_concluded),

--- a/src/opossum_lib/spdx/convert_to_opossum.py
+++ b/src/opossum_lib/spdx/convert_to_opossum.py
@@ -5,6 +5,7 @@
 import logging
 import sys
 import uuid
+from pathlib import PurePath
 from typing import Any
 
 from networkx import DiGraph
@@ -74,9 +75,7 @@ def convert_spdx_to_opossum_information(filename: str) -> OpossumFileContent:
 
 def convert_tree_to_opossum(tree: DiGraph) -> Opossum:
     metadata = create_metadata(tree)
-    resources = []  # Resource(type=ResourceType.TOP_LEVEL)
-    # resources_to_attributions: dict[str, list[str]] = dict()
-    # external_attributions: dict[str, OpossumPackage] = dict()
+    resources = []
     attribution_to_id: dict[OpossumPackage, str] = {}
     attribution_breakpoints = []
     external_attribution_sources = {
@@ -98,7 +97,7 @@ def convert_tree_to_opossum(tree: DiGraph) -> Opossum:
                 "A tree should always have a node without incoming edge."
             )
         source_file_path = _get_file_path(connected_subgraph, source, source)
-        rootnode = Resource(path=source_file_path)
+        rootnode = Resource(path=PurePath(source_file_path))
         resources.append(rootnode)
         for node_label in connected_subgraph.nodes():
             node = connected_subgraph.nodes[node_label]

--- a/tests/data/expected_opossum.json
+++ b/tests/data/expected_opossum.json
@@ -109,10 +109,10 @@
     }
   },
   "resourcesToAttributions":{
-    "/SPDX Lite Document/":[
+    "/SPDX Lite Document":[
       "SPDXRef-DOCUMENT"
     ],
-    "/SPDX Lite Document/DESCRIBES/Package A/":[
+    "/SPDX Lite Document/DESCRIBES/Package A":[
       "SPDXRef-Package-A"
     ],
     "/SPDX Lite Document/DESCRIBES/Package B":[
@@ -124,7 +124,7 @@
     "/SPDX Lite Document/DESCRIBES/Package A/CONTAINS/File-C":[
       "SPDXRef-File-C"
     ],
-    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/":[
+    "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C":[
       "SPDXRef-Package-C"
     ],
     "/SPDX Lite Document/DESCRIBES/Package A/COPY_OF/Package C/CONTAINS/File-B":[

--- a/tests/test_spdx/test_attribution_creation.py
+++ b/tests/test_spdx/test_attribution_creation.py
@@ -54,7 +54,7 @@ def test_create_package_attribution() -> None:
     write_package(package, package_data)
     package_attribution = create_package_attribution(package)
 
-    assert package_attribution == OpossumPackage(
+    assert package_attribution.to_opossum_file_format() == OpossumPackage(
         source=SourceInfo(name=SPDX_PACKAGE_IDENTIFIER),
         comment=package_data.getvalue(),
         package_name=package.name,
@@ -79,7 +79,7 @@ def test_create_file_attribution() -> None:
     write_file(file, file_data)
     file_attribution = create_file_attribution(file)
 
-    assert file_attribution == OpossumPackage(
+    assert file_attribution.to_opossum_file_format() == OpossumPackage(
         source=SourceInfo(name=SPDX_FILE_IDENTIFIER),
         comment=file_data.getvalue(),
         package_name=file.name,
@@ -102,7 +102,7 @@ def test_create_snippet_attribution() -> None:
     write_snippet(snippet, snippet_data)
     snippet_attribution = create_snippet_attribution(snippet)
 
-    assert snippet_attribution == OpossumPackage(
+    assert snippet_attribution.to_opossum_file_format() == OpossumPackage(
         source=SourceInfo(name=SPDX_SNIPPET_IDENTIFIER),
         comment=snippet_data.getvalue(),
         package_name=snippet.name,
@@ -124,7 +124,7 @@ def test_create_document_attribution() -> None:
     write_creation_info(creation_info, creation_info_data)
     document_attribution = create_document_attribution(creation_info)
 
-    assert document_attribution == OpossumPackage(
+    assert document_attribution.to_opossum_file_format() == OpossumPackage(
         source=SourceInfo(name=DOCUMENT_SPDX_ID),
         package_name=creation_info.name,
         license_name=creation_info.data_license,

--- a/tests/test_spdx/test_extract_opossum_information_from_spdx.py
+++ b/tests/test_spdx/test_extract_opossum_information_from_spdx.py
@@ -19,7 +19,7 @@ from opossum_lib.spdx.constants import (
     SPDX_PACKAGE_IDENTIFIER,
     SPDX_SNIPPET_IDENTIFIER,
 )
-from opossum_lib.spdx.convert_to_opossum import convert_tree_to_opossum_information
+from opossum_lib.spdx.convert_to_opossum import convert_tree_to_opossum
 from opossum_lib.spdx.graph_generation import generate_graph_from_spdx
 from opossum_lib.spdx.tree_generation import generate_tree_from_graph
 from tests.test_spdx.helper_methods import (
@@ -52,12 +52,12 @@ def test_different_paths_graph() -> None:
         ],
     )
     assert opossum_information.resources_to_attributions == {
-        "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
-        "/SPDX Lite Document/DESCRIBES/Example package A/": ["SPDXRef-Package-A"],
+        "/SPDX Lite Document": ["SPDXRef-DOCUMENT"],
+        "/SPDX Lite Document/DESCRIBES/Example package A": ["SPDXRef-Package-A"],
         "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
             "SPDXRef-File"
         ],
-        "/SPDX Lite Document/DESCRIBES/Example package B/": ["SPDXRef-Package-B"],
+        "/SPDX Lite Document/DESCRIBES/Example package B": ["SPDXRef-Package-B"],
         "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
             "SPDXRef-File"
         ],
@@ -119,12 +119,12 @@ def test_unconnected_paths_graph() -> None:
     )
 
     assert opossum_information.resources_to_attributions == {
-        "/SPDX Lite Document/": ["SPDXRef-DOCUMENT"],
-        "/SPDX Lite Document/DESCRIBES/Example package A/": ["SPDXRef-Package-A"],
+        "/SPDX Lite Document": ["SPDXRef-DOCUMENT"],
+        "/SPDX Lite Document/DESCRIBES/Example package A": ["SPDXRef-Package-A"],
         "/SPDX Lite Document/DESCRIBES/Example package A/CONTAINS/Example file": [
             "SPDXRef-File"
         ],
-        "/SPDX Lite Document/DESCRIBES/Example package B/": ["SPDXRef-Package-B"],
+        "/SPDX Lite Document/DESCRIBES/Example package B": ["SPDXRef-Package-B"],
         "/SPDX Lite Document/DESCRIBES/Example package B/CONTAINS/Example file": [
             "SPDXRef-File"
         ],
@@ -180,10 +180,10 @@ def test_different_roots_graph() -> None:
     )
 
     assert opossum_information.resources_to_attributions == {
-        "/File-B/": ["SPDXRef-File-B"],
+        "/File-B": ["SPDXRef-File-B"],
         "/File-B/DESCRIBES/Package-B": ["SPDXRef-Package-B"],
-        "/Document/": ["SPDXRef-DOCUMENT"],
-        "/Document/DESCRIBES/Package-A/": ["SPDXRef-Package-A"],
+        "/Document": ["SPDXRef-DOCUMENT"],
+        "/Document/DESCRIBES/Package-A": ["SPDXRef-Package-A"],
         "/Document/DESCRIBES/Package-A/CONTAINS/File-A": ["SPDXRef-File-A"],
         "/Document/DESCRIBES/Package-B": ["SPDXRef-Package-B"],
     }
@@ -276,5 +276,5 @@ def _get_opossum_information_from_file(file_name: str) -> OpossumInformation:
 def _get_opossum_information_from_document(document: Document) -> OpossumInformation:
     graph = generate_graph_from_spdx(document)
     tree = generate_tree_from_graph(graph)
-    opossum_information = convert_tree_to_opossum_information(tree)
-    return opossum_information
+    opossum_information = convert_tree_to_opossum(tree)
+    return opossum_information.to_opossum_file_format().input_file

--- a/tests/test_spdx/test_helper_methods.py
+++ b/tests/test_spdx/test_helper_methods.py
@@ -1,15 +1,12 @@
 # SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from unittest import TestCase
 
 import pytest
 from networkx import DiGraph
 
-from opossum_lib.opossum.opossum_file import ResourceType
 from opossum_lib.spdx.helper_methods import (
     _create_file_path_from_graph_path,
-    _replace_node_ids_with_labels_and_add_resource_type,
 )
 
 
@@ -22,28 +19,7 @@ def test_create_file_path_from_graph_path(node_label: str) -> None:
 
     file_path = _create_file_path_from_graph_path(path, graph)
 
-    assert file_path == "/root/node/with/path/leaf"
-
-
-@pytest.mark.parametrize(
-    "node_label", ["node/with/path", "./node/with/path", "/node/with/path"]
-)
-def test_replace_node_ids_with_labels(node_label: str) -> None:
-    graph = _create_simple_graph(node_label)
-    path = ["root", "node", "leaf"]
-
-    file_path = _replace_node_ids_with_labels_and_add_resource_type(path, graph)
-
-    TestCase().assertCountEqual(
-        file_path,
-        [
-            ("root", ResourceType.OTHER),
-            ("node", ResourceType.OTHER),
-            ("with", ResourceType.OTHER),
-            ("path", ResourceType.OTHER),
-            ("leaf", ResourceType.OTHER),
-        ],
-    )
+    assert file_path == "root/node/with/path/leaf"
 
 
 def _create_simple_graph(node_label: str) -> DiGraph:


### PR DESCRIPTION
## Summary of changes
* minor changes to attribution_generation.py and helper_methods.py
* convert_to_opossum.py now uses opossum_model.Resource which simplifies the logic
* this caused some tests to change:
  - (minor) some tests require a conversion to opossum file format
  - resources_to_attribution used to have trailing "/" for folders which are no longer generated. This should have no impact on the validity of the .opossum file

## Context and reason for change
Continuation of #190 

Closes #197 
tests follow separately (tracked by #205 )