### PR TITLE
chore: rename linux build

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ['3.13']
         include:
           - os: ubuntu-latest
-            asset-name: opossum-file-for-ubuntu
+            asset-name: opossum-file-for-linux
           - os: macos-latest
             asset-name: opossum-file-for-mac
           - os: windows-latest


### PR DESCRIPTION
renames the artifact build under ubuntu from `opossum-file-for-ubuntu` to `opossum-file-for-linux`.

This change requires changing the [installer script in OpossumUI](https://github.com/opossum-tool/OpossumUI/blob/3f12f10a9ab93720155c17977d76abe7e458a0f5/package.json#L148) accordingly.