### PR TITLE
Publish two MacOS executables on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,13 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
         python-version: ['3.13']
         include:
           - os: ubuntu-latest
             asset-name: opossum-file-for-linux
+          - os: macos-13
+            asset-name: opossum-file-for-mac-intel
           - os: macos-latest
-            asset-name: opossum-file-for-mac
+            asset-name: opossum-file-for-mac-arm64
           - os: windows-latest
             asset-name: opossum-file-for-windows.exe
 


### PR DESCRIPTION
Adjusted publish-release.yml to build and publish opossum-file executables for both Intel and ARM64 architecture based MacOS systems.

Can be tested by creating a temporary pre-release based on this branch.