### PR TITLE
fix: Faker seed should be random

### DIFF
--- a/src/opossum_lib/core/entities/scan_results.py
+++ b/src/opossum_lib/core/entities/scan_results.py
@@ -35,7 +35,7 @@ class ScanResults(BaseModel):
     files_with_children: list[str] = []
     base_urls_for_sources: BaseUrlsForSources = BaseUrlsForSources()
     attribution_to_id: dict[OpossumPackage, str] = {}
-    unassigned_attributions: list[OpossumPackage] = []
+    unassigned_attributions: set[OpossumPackage] = set()
 
     def to_opossum_file_model(self) -> OpossumInputFileModel:
         external_attributions, resources_to_attributions = (

--- a/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
@@ -99,12 +99,12 @@ def _get_unassigned_attributions(
         OpossumPackageIdentifierModel,
         OpossumPackageModel,
     ],
-) -> list[OpossumPackage] | None:
+) -> set[OpossumPackage] | None:
     available_attribution_ids = external_attributions.keys()
     unused_attributions_ids = set(available_attribution_ids) - used_attribution_ids
-    unused_attributions = [
+    unused_attributions = {
         _convert_package(external_attributions[id]) for id in unused_attributions_ids
-    ]
+    }
     return unused_attributions
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+from datetime import datetime
+
 import pytest
 from faker.proxy import Faker
 
@@ -26,3 +28,10 @@ def scancode_faker(faker: Faker) -> ScanCodeFaker:
 @pytest.fixture
 def opossum_faker(faker: Faker) -> OpossumFaker:
     return setup_opossum_faker(faker)
+
+
+@pytest.fixture(autouse=True)
+def faker_seed() -> int:
+    seed = int(datetime.now().timestamp())
+    print("\nSeeding faker with ", seed)
+    return seed

--- a/tests/core/entities/generators/scan_results_provider.py
+++ b/tests/core/entities/generators/scan_results_provider.py
@@ -61,15 +61,17 @@ class ScanResultsProvider(BaseProvider):
         files_with_children: list[str] | None = None,
         base_urls_for_sources: BaseUrlsForSources | None = None,
         attribution_to_id: dict[OpossumPackage, str] | None = None,
-        unassigned_attributions: list[OpossumPackage] | None = None,
+        unassigned_attributions: set[OpossumPackage] | None = None,
     ) -> ScanResults:
         generated_resources = resources or [self.resource_provider.resource_tree()]
-        generated_unassigned_attributions = unassigned_attributions or []
+        generated_unassigned_attributions = unassigned_attributions or set()
         if unassigned_attributions is None:
-            generated_unassigned_attributions = random_list(
-                self,
-                entry_generator=lambda: self.package_provider.package(),
-                min_number_of_entries=0,
+            generated_unassigned_attributions = set(
+                random_list(
+                    self,
+                    entry_generator=lambda: self.package_provider.package(),
+                    min_number_of_entries=0,
+                )
             )
 
         generated_frequent_licenses = frequent_licenses or []
@@ -103,7 +105,7 @@ class ScanResultsProvider(BaseProvider):
     def _attribution_to_id(
         self,
         resources: list[Resource] | None,
-        unassigned_attributions: list[OpossumPackage] | None,
+        unassigned_attributions: set[OpossumPackage] | None,
     ) -> dict[OpossumPackage, str]:
         attributions = []
 
@@ -123,7 +125,7 @@ class ScanResultsProvider(BaseProvider):
                 attributions += get_attributions_from_resource_tree(resource)
 
         if unassigned_attributions:
-            attributions += unassigned_attributions
+            attributions += list(unassigned_attributions)
 
         return {attribution: str(uuid.uuid4()) for attribution in attributions}
 

--- a/tests/core/entities/test_opossum.py
+++ b/tests/core/entities/test_opossum.py
@@ -38,15 +38,6 @@ class TestOpossumToOpossumModelConversion:
         # this can change due to the generation of new ids
         expected_result_dict["scan_results"]["attribution_to_id"] = None
         result_dict["scan_results"]["attribution_to_id"] = None
-        # sort the lists again for comparability
-        expected_result_dict["scan_results"]["unassigned_attributions"] = sorted(
-            expected_result_dict["scan_results"]["unassigned_attributions"],
-            key=lambda x: x["source"]["name"],
-        )
-        result_dict["scan_results"]["unassigned_attributions"] = sorted(
-            result_dict["scan_results"]["unassigned_attributions"],
-            key=lambda x: x["source"]["name"],
-        )
 
         assert result_dict == expected_result_dict
 

--- a/tests/setup/opossum_faker_setup.py
+++ b/tests/setup/opossum_faker_setup.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Any, cast
 
 from faker import Faker, Generator
@@ -37,7 +36,4 @@ def setup_opossum_faker(faker: Faker) -> OpossumFaker:
     faker.add_provider(OpossumProvider)
     faker.add_provider(ScanResultsProvider)
     faker = cast(OpossumFaker, faker)
-    seed = int(datetime.now().timestamp())
-    Faker.seed(seed)
-    print("\nSeeding faker with ", seed)
     return faker

--- a/tests/setup/opossum_file_faker_setup.py
+++ b/tests/setup/opossum_file_faker_setup.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Any, cast
 
 from faker import Faker, Generator
@@ -72,7 +71,4 @@ def setup_opossum_file_faker(faker: Faker) -> OpossumFileFaker:
     faker.add_provider(OpossumOutputFileProvider)
     faker.add_provider(OpossumFileContentProvider)
     faker = cast(OpossumFileFaker, faker)
-    seed = int(datetime.now().timestamp())
-    Faker.seed(seed)
-    print("\nSeeding faker with ", seed)
     return faker

--- a/tests/setup/scancode_faker_setup.py
+++ b/tests/setup/scancode_faker_setup.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Sequence
-from datetime import datetime
 from typing import Any, cast
 
 from faker import Faker, Generator
@@ -31,7 +30,7 @@ class ScanCodeFaker(Faker):
         super().__init__(
             locale, providers, generator, includes, use_weighting, **config
         )
-        scdp = ScanCodeDataProvider(self)
+        scdp = ScanCodeDataProvider(generator)
         self.scancode_data_provider = scdp
         self.generate_path_structure = scdp.generate_path_structure
         self.files = scdp.files
@@ -53,7 +52,4 @@ class ScanCodeFaker(Faker):
 def setup_scancode_faker(faker: Faker) -> ScanCodeFaker:
     faker.add_provider(ScanCodeDataProvider)
     faker = cast(ScanCodeFaker, faker)
-    seed = int(datetime.now().timestamp())
-    Faker.seed(seed)
-    print("\nSeeding ScanCode faker with ", seed)
     return faker


### PR DESCRIPTION
## Summary of changes

* changes the seeding of Faker to guarantee a random seed for every run

## Context and reason for change

The strength of Faker is the random generation of valid inputs. With a fixed seed this advantage is lost. For incomprehensible reasons, there was no randomization taking place. This PR fixes that be altering the setup slightly.

## How the changes can be tested

Dump a few generated documents, e.g. by putting this snippet:
```python
def test_generate(scancode_faker: ScanCodeFaker) -> None:
    scancode_data = scancode_faker.scancode_data()
    seed = int(datetime.now().timestamp())
    with open(f"generated_scancode-{seed}.json", "w") as out:
        out.write(scancode_data.model_dump_json(indent=4))
```
at the end of `tests/input_formats/scancode/services/test_convert_to_opossum.py` and running it a couple of times.
Before this change, this yields identical files. After this change, the file is different everytime.