### PR TITLE
Cleanup the Faker class stubs

### DIFF
--- a/tests/setup/opossum_faker_setup.py
+++ b/tests/setup/opossum_faker_setup.py
@@ -1,64 +1,74 @@
 # SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
 #
 # SPDX-License-Identifier: Apache-2.0
-from collections.abc import Sequence
-from typing import Any, cast
+from typing import cast
 
-from faker import Faker, Generator
+from faker import Faker
 
+from tests.core.entities.generators.external_attribution_source_provider import (
+    ExternalAttributionSourceProvider,
+)
+from tests.core.entities.generators.frequent_license_provider import (
+    FrequentLicenseProvider,
+)
+from tests.core.entities.generators.metadata_provider import MetadataProvider
 from tests.core.entities.generators.opossum_provider import OpossumProvider
 from tests.core.entities.generators.package_provider import PackageProvider
 from tests.core.entities.generators.resource_provider import ResourceProvider
 from tests.core.entities.generators.scan_results_provider import ScanResultsProvider
+from tests.core.entities.generators.source_info_provider import SourceInfoProvider
 from tests.input_formats.opossum.entities.generators.generate_outfile_information import (  # noqa: E501
     OpossumOutputFileProvider,
 )
 
 
+## This class serves as a stub to enable tab-completion in the tests and satisfy mypy
 class OpossumFaker(Faker):
-    opossum_provider: OpossumProvider
-    scan_results_provider: ScanResultsProvider
-    review_result_provider: OpossumOutputFileProvider
-
-    def __init__(
-        self,
-        locale: str | Sequence[str] | dict[str, int | float] | None = None,
-        providers: list[str] | None = None,
-        generator: Generator | None = None,
-        includes: list[str] | None = None,
-        use_weighting: bool = True,
-        **config: Any,
-    ):
-        super().__init__(
-            locale, providers, generator, includes, use_weighting, **config
-        )
-        self.opossum_provider = OpossumProvider(self)
-        self.scan_results_provider = ScanResultsProvider(self)
-        self.review_result_provider = OpossumOutputFileProvider(self)
-        self.package_provider = PackageProvider(self)
-        self.resource_provider = ResourceProvider(self)
-        self.opossum = self.opossum_provider.opossum
-        self.scan_results = self.scan_results_provider.scan_results
-        self.output_file = self.review_result_provider.output_file
-        self.outfile_metadata = self.review_result_provider.outfile_metadata
-        self.manual_attributions = self.review_result_provider.manual_attributions
+    def __init__(self) -> None:
+        opossum_provider = OpossumProvider(self)
+        scan_results_provider = ScanResultsProvider(self)
+        review_result_provider = OpossumOutputFileProvider(self)
+        metadata_provider = MetadataProvider(self)
+        package_provider = PackageProvider(self)
+        resource_provider = ResourceProvider(self)
+        external_attribution_source_provider = ExternalAttributionSourceProvider(self)
+        frequent_license_provider = FrequentLicenseProvider(self)
+        source_info_provider = SourceInfoProvider(self)
+        self.opossum = opossum_provider.opossum
+        self.scan_results = scan_results_provider.scan_results
+        self.output_file = review_result_provider.output_file
+        self.outfile_metadata = review_result_provider.outfile_metadata
+        self.manual_attributions = review_result_provider.manual_attributions
         self.resources_to_attributions = (
-            self.review_result_provider.resources_to_attributions
+            review_result_provider.resources_to_attributions
         )
         self.resolved_external_attributions = (
-            self.review_result_provider.resolved_external_attributions
+            review_result_provider.resolved_external_attributions
         )
-        self.package = self.package_provider.package
-        self.resource = self.resource_provider.resource
-        self.resource_tree = self.resource_provider.resource_tree
-        self.resource_type = self.resource_provider.resource_type
+        self.metadata = metadata_provider.metadata
+        self.package = package_provider.package
+        self.resource = resource_provider.resource
+        self.resource_tree = resource_provider.resource_tree
+        self.resource_type = resource_provider.resource_type
+        self.external_attribution_source = (
+            external_attribution_source_provider.external_attribution_source
+        )
+        self.external_attribution_sources = (
+            external_attribution_source_provider.external_attribution_sources
+        )
+        self.frequent_license = frequent_license_provider.frequent_license
+        self.source_info = source_info_provider.source_info
 
 
 def setup_opossum_faker(faker: Faker) -> OpossumFaker:
     faker.add_provider(OpossumProvider)
     faker.add_provider(ScanResultsProvider)
     faker.add_provider(OpossumOutputFileProvider)
+    faker.add_provider(MetadataProvider)
     faker.add_provider(PackageProvider)
     faker.add_provider(ResourceProvider)
+    faker.add_provider(ExternalAttributionSourceProvider)
+    faker.add_provider(FrequentLicenseProvider)
+    faker.add_provider(SourceInfoProvider)
     faker = cast(OpossumFaker, faker)
     return faker

--- a/tests/setup/opossum_file_faker_setup.py
+++ b/tests/setup/opossum_file_faker_setup.py
@@ -2,10 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Sequence
-from typing import Any, cast
+from typing import cast
 
-from faker import Faker, Generator
+from faker import Faker
 
 from tests.input_formats.opossum.entities.generators.generate_file_information import (
     FileInformationProvider,
@@ -19,63 +18,42 @@ from tests.input_formats.opossum.entities.generators.generate_outfile_informatio
 )
 
 
+## This class serves as a stub to enable tab-completion in the tests and satisfy mypy
 class OpossumFileFaker(Faker):
-    file_information_provider: FileInformationProvider
-    metadata_provider: MetadataProvider
-    opossum_output_file_provider: OpossumOutputFileProvider
-    opossum_file_content_provider: OpossumFileContentProvider
-
-    def __init__(
-        self,
-        locale: str | Sequence[str] | dict[str, int | float] | None = None,
-        providers: list[str] | None = None,
-        generator: Generator | None = None,
-        includes: list[str] | None = None,
-        use_weighting: bool = True,
-        **config: Any,
-    ):
-        super().__init__(
-            locale, providers, generator, includes, use_weighting, **config
-        )
-        self.file_information_provider = FileInformationProvider(self)
-        self.metadata_provider = MetadataProvider(self)
-        self.opossum_file_content_provider = OpossumFileContentProvider(self)
-        self.opossum_output_file_provider = OpossumOutputFileProvider(self)
-        self.opossum_file_information = (
-            self.file_information_provider.opossum_file_information
-        )
-        self.opossum_input_metadata = self.metadata_provider.opossum_input_metadata
-        self.opossum_package = self.file_information_provider.opossum_package
-        self.external_attributions = (
-            self.file_information_provider.external_attributions
-        )
-        self.attribution_breakpoints = (
-            self.file_information_provider.attribution_breakpoints
-        )
-        self.external_attribution_sources = (
-            self.file_information_provider.external_attribution_sources
-        )
-        self.external_attribution_source = (
-            self.file_information_provider.external_attribution_source
-        )
-        self.output_file = self.opossum_output_file_provider.output_file
-        self.outfile_metadata = self.opossum_output_file_provider.outfile_metadata
-        self.manual_attributions = self.opossum_output_file_provider.manual_attributions
+    def __init__(self) -> None:
+        opossum_file_content_provider = OpossumFileContentProvider(self)
+        opossum_output_file_provider = OpossumOutputFileProvider(self)
+        file_information_provider = FileInformationProvider(self)
+        metadata_provider = MetadataProvider(self)
+        self.opossum_file_content = opossum_file_content_provider.opossum_file_content
+        self.output_file = opossum_output_file_provider.output_file
+        self.outfile_metadata = opossum_output_file_provider.outfile_metadata
+        self.manual_attributions = opossum_output_file_provider.manual_attributions
         self.resources_to_attributions = (
-            self.opossum_output_file_provider.resources_to_attributions
+            opossum_output_file_provider.resources_to_attributions
         )
         self.resolved_external_attributions = (
-            self.opossum_output_file_provider.resolved_external_attributions
+            opossum_output_file_provider.resolved_external_attributions
         )
-        self.opossum_file_content = (
-            self.opossum_file_content_provider.opossum_file_content
+        self.opossum_file_information = (
+            file_information_provider.opossum_file_information
         )
+        self.opossum_package = file_information_provider.opossum_package
+        self.external_attributions = file_information_provider.external_attributions
+        self.attribution_breakpoints = file_information_provider.attribution_breakpoints
+        self.external_attribution_sources = (
+            file_information_provider.external_attribution_sources
+        )
+        self.external_attribution_source = (
+            file_information_provider.external_attribution_source
+        )
+        self.opossum_input_metadata = metadata_provider.opossum_input_metadata
 
 
 def setup_opossum_file_faker(faker: Faker) -> OpossumFileFaker:
-    faker.add_provider(MetadataProvider)
-    faker.add_provider(FileInformationProvider)
-    faker.add_provider(OpossumOutputFileProvider)
     faker.add_provider(OpossumFileContentProvider)
+    faker.add_provider(OpossumOutputFileProvider)
+    faker.add_provider(FileInformationProvider)
+    faker.add_provider(MetadataProvider)
     faker = cast(OpossumFileFaker, faker)
     return faker

--- a/tests/setup/scancode_faker_setup.py
+++ b/tests/setup/scancode_faker_setup.py
@@ -2,36 +2,19 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from collections.abc import Sequence
-from typing import Any, cast
+from typing import cast
 
-from faker import Faker, Generator
+from faker import Faker
 
 from tests.input_formats.scancode.entities.generators.generate_scancode_file import (
     ScanCodeDataProvider,
 )
 
 
+## This class serves as a stub to enable tab-completion in the tests and satisfy mypy
 class ScanCodeFaker(Faker):
-    scancode_data_provider: ScanCodeDataProvider
-    # metadata_provider: MetadataProvider
-    # opossum_output_file_provider: OpossumOutputFileProvider
-    # opossum_file_content_provider: OpossumFileContentProvider
-
-    def __init__(
-        self,
-        locale: str | Sequence[str] | dict[str, int | float] | None = None,
-        providers: list[str] | None = None,
-        generator: Generator | None = None,
-        includes: list[str] | None = None,
-        use_weighting: bool = True,
-        **config: Any,
-    ):
-        super().__init__(
-            locale, providers, generator, includes, use_weighting, **config
-        )
-        scdp = ScanCodeDataProvider(generator)
-        self.scancode_data_provider = scdp
+    def __init__(self) -> None:
+        scdp = ScanCodeDataProvider(self)
         self.generate_path_structure = scdp.generate_path_structure
         self.files = scdp.files
         self.sc_email = scdp.email


### PR DESCRIPTION
## Summary of changes
Simplify the Faker type definitions:
* remove unused class attributes
* reduce the constructors to bare minimum (they are never executed anyhow)
* remove internal providers from instance variables (they are not accessible in the tests)
* add missing providers and their methods
* add comment explaining the purpose of these classes

## Context and reason for change
We use these classes to help the IDE know which methods are available on the Faker instance in the tests and also to communicate that information to mypy. As such these classes are neither used nor instanced and can be kept to a bare minimum. 

## How the changes can be tested
There should be no functional difference. Code completion for methods of specific Faker types in the test should still work. Mypy should not raise any concerns.