### PR TITLE
refactor: introduce RootResource

### DIFF
--- a/src/opossum_lib/core/entities/root_resource.py
+++ b/src/opossum_lib/core/entities/root_resource.py
@@ -1,0 +1,42 @@
+#  SPDX-FileCopyrightText: TNG Technology Consulting GmbH <https://www.tngtech.com>
+#  #
+#  SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Generator
+from pathlib import PurePath
+
+from pydantic import BaseModel, ConfigDict
+
+from opossum_lib.core.entities.resource import Resource
+from opossum_lib.shared.entities.opossum_input_file_model import ResourceInFileModel
+
+
+class RootResource(BaseModel):
+    model_config = ConfigDict(frozen=False, extra="forbid")
+    children: dict[str, Resource] = {}
+
+    def add_resource(self, resource: Resource) -> None:
+        remaining_path_parts = resource.path.parts
+        if not remaining_path_parts:
+            raise RuntimeError(f"Every resource needs a filepath. Got: {resource}")
+        first_path_segment = remaining_path_parts[0]
+        if first_path_segment not in self.children:
+            self.children[first_path_segment] = Resource(
+                path=PurePath(first_path_segment)
+            )
+        self.children[first_path_segment].add_resource(resource)
+
+    def to_opossum_file_model(self) -> ResourceInFileModel:
+        return {
+            child.path.as_posix(): child.to_opossum_file_model()
+            for child in self.children.values()
+        }
+
+    def all_resources(self) -> Generator[Resource]:
+        def iterate(node: Resource) -> Generator[Resource]:
+            yield node
+            for child in node.children.values():
+                yield from iterate(child)
+
+        for child in self.children.values():
+            yield from iterate(child)

--- a/src/opossum_lib/core/entities/scan_results.py
+++ b/src/opossum_lib/core/entities/scan_results.py
@@ -16,8 +16,8 @@ from opossum_lib.core.entities.external_attribution_source import (
 from opossum_lib.core.entities.frequent_license import FrequentLicense
 from opossum_lib.core.entities.metadata import Metadata
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import (
-    TopLevelResource,
+from opossum_lib.core.entities.root_resource import (
+    RootResource,
 )
 from opossum_lib.shared.entities.opossum_input_file_model import (
     OpossumInputFileModel,
@@ -30,7 +30,7 @@ from opossum_lib.shared.entities.opossum_input_file_model import (
 class ScanResults(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
     metadata: Metadata
-    resources: TopLevelResource = TopLevelResource()
+    resources: RootResource = RootResource()
     attribution_breakpoints: list[str] = []
     external_attribution_sources: dict[str, ExternalAttributionSource] = {}
     frequent_licenses: list[FrequentLicense] = []
@@ -86,7 +86,7 @@ class ScanResults(BaseModel):
 
     def create_attribution_mapping(
         self,
-        resources: TopLevelResource,
+        resources: RootResource,
     ) -> tuple[
         dict[OpossumPackageIdentifierModel, OpossumPackageModel],
         dict[ResourcePathModel, list[OpossumPackageIdentifierModel]],

--- a/src/opossum_lib/core/services/merge_opossums.py
+++ b/src/opossum_lib/core/services/merge_opossums.py
@@ -19,7 +19,7 @@ from opossum_lib.core.entities.opossum import (
     ScanResults,
 )
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import TopLevelResource
+from opossum_lib.core.entities.root_resource import RootResource
 from opossum_lib.shared.entities.opossum_output_file_model import (
     Metadata as OutputMetadata,
 )
@@ -101,11 +101,11 @@ def _merge_metadata(scan_results: list[ScanResults]) -> Metadata:
     )
 
 
-def _merge_resources(scan_results: list[ScanResults]) -> TopLevelResource:
-    new_root = TopLevelResource()
+def _merge_resources(scan_results: list[ScanResults]) -> RootResource:
+    new_root = RootResource()
     for scan_result in scan_results:
         for resource in scan_result.resources.all_resources():
-            new_root.add_resource(resource.model_copy(deep=True))
+            new_root.add_resource(resource)
 
     return new_root
 
@@ -195,7 +195,7 @@ def _merge_unassigned_attributions(
 
 
 def _remove_assigned_attributions(
-    resources: TopLevelResource, unassigned_attributions: set[OpossumPackage]
+    resources: RootResource, unassigned_attributions: set[OpossumPackage]
 ) -> list[OpossumPackage]:
     all_attributions = set()
     for resource in resources.all_resources():

--- a/src/opossum_lib/core/services/merge_opossums.py
+++ b/src/opossum_lib/core/services/merge_opossums.py
@@ -7,7 +7,6 @@ import logging
 import uuid
 from collections import OrderedDict
 from collections.abc import Iterable
-from pathlib import PurePath
 
 from opossum_lib.core.entities.base_url_for_sources import BaseUrlsForSources
 from opossum_lib.core.entities.external_attribution_source import (
@@ -20,7 +19,7 @@ from opossum_lib.core.entities.opossum import (
     ScanResults,
 )
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource
+from opossum_lib.core.entities.resource import TopLevelResource
 from opossum_lib.shared.entities.opossum_output_file_model import (
     Metadata as OutputMetadata,
 )
@@ -102,20 +101,13 @@ def _merge_metadata(scan_results: list[ScanResults]) -> Metadata:
     )
 
 
-def _merge_resources(scan_results: list[ScanResults]) -> list[Resource]:
-    def add_all(root: Resource, current: Resource) -> None:
-        copy = current.model_copy()
-        copy.children = {}
-        root.add_resource(copy)
-        for child in current.children.values():
-            add_all(root, child)
-
-    temp_root = Resource(path=PurePath(""))
+def _merge_resources(scan_results: list[ScanResults]) -> TopLevelResource:
+    new_root = TopLevelResource()
     for scan_result in scan_results:
-        for resource in scan_result.resources:
-            add_all(temp_root, resource)
+        for resource in scan_result.resources.all_resources():
+            new_root.add_resource(resource.model_copy(deep=True))
 
-    return list(temp_root.children.values())
+    return new_root
 
 
 def _merge_unique_order_preserving[T](lists: Iterable[list[T]]) -> list[T]:
@@ -203,20 +195,11 @@ def _merge_unassigned_attributions(
 
 
 def _remove_assigned_attributions(
-    resources: list[Resource], unassigned_attributions: set[OpossumPackage]
+    resources: TopLevelResource, unassigned_attributions: set[OpossumPackage]
 ) -> list[OpossumPackage]:
-    all_attributions_list = []
-
-    def extract_attributions(resource: Resource) -> None:
-        nonlocal all_attributions_list
-        all_attributions_list += resource.attributions
-        for child in resource.children.values():
-            extract_attributions(child)
-
-    for resource in resources:
-        extract_attributions(resource)
-
-    all_attributions = set(all_attributions_list)
+    all_attributions = set()
+    for resource in resources.all_resources():
+        all_attributions |= set(resource.attributions)
 
     return [
         attribution

--- a/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
@@ -18,8 +18,8 @@ from opossum_lib.core.entities.opossum_package import OpossumPackage
 from opossum_lib.core.entities.resource import (
     Resource,
     ResourceType,
-    TopLevelResource,
 )
+from opossum_lib.core.entities.root_resource import RootResource
 from opossum_lib.core.entities.scan_results import ScanResults
 from opossum_lib.core.entities.source_info import SourceInfo
 from opossum_lib.shared.entities.opossum_file_model import OpossumFileModel
@@ -143,7 +143,7 @@ def _convert_to_resource_tree(
         ResourcePathModel,
         list[OpossumPackageIdentifierModel],
     ],
-) -> tuple[TopLevelResource, set[OpossumPackageIdentifierModel]]:
+) -> tuple[RootResource, set[OpossumPackageIdentifierModel]]:
     used_attribution_ids = set()
 
     def generate_child_resource(
@@ -194,7 +194,7 @@ def _convert_to_resource_tree(
     root_path = PurePath("")
 
     if isinstance(resources, dict):
-        return TopLevelResource(
+        return RootResource(
             children={
                 relative_path: generate_child_resource(root_path / relative_path, child)
                 for relative_path, child in resources.items()

--- a/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/opossum/services/convert_to_opossum.py
@@ -18,7 +18,7 @@ from opossum_lib.core.entities.opossum_package import OpossumPackage
 from opossum_lib.core.entities.resource import (
     Resource,
     ResourceType,
-    _convert_path_to_str,
+    TopLevelResource,
 )
 from opossum_lib.core.entities.scan_results import ScanResults
 from opossum_lib.core.entities.source_info import SourceInfo
@@ -143,7 +143,7 @@ def _convert_to_resource_tree(
         ResourcePathModel,
         list[OpossumPackageIdentifierModel],
     ],
-) -> tuple[list[Resource], set[OpossumPackageIdentifierModel]]:
+) -> tuple[TopLevelResource, set[OpossumPackageIdentifierModel]]:
     used_attribution_ids = set()
 
     def generate_child_resource(
@@ -151,7 +151,7 @@ def _convert_to_resource_tree(
         to_insert: ResourceInFileModel,
     ) -> Resource:
         path = current_path
-        current_path_as_string = _convert_path_to_str(current_path)
+        current_path_as_string = current_path.as_posix()
         if not current_path_as_string.startswith("/"):
             current_path_as_string = "/" + current_path_as_string
         attributions, attribution_ids = _get_applicable_attributions(
@@ -194,10 +194,12 @@ def _convert_to_resource_tree(
     root_path = PurePath("")
 
     if isinstance(resources, dict):
-        return [
-            generate_child_resource(root_path / relative_path, child)
-            for relative_path, child in resources.items()
-        ], used_attribution_ids
+        return TopLevelResource(
+            children={
+                relative_path: generate_child_resource(root_path / relative_path, child)
+                for relative_path, child in resources.items()
+            }
+        ), used_attribution_ids
     else:
         raise RuntimeError("Root node must not be of file type")
 

--- a/src/opossum_lib/input_formats/scancode/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/scancode/services/convert_to_opossum.py
@@ -12,7 +12,8 @@ from opossum_lib.core.entities.opossum import (
     Opossum,
 )
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, ResourceType, TopLevelResource
+from opossum_lib.core.entities.resource import Resource, ResourceType
+from opossum_lib.core.entities.root_resource import RootResource
 from opossum_lib.core.entities.scan_results import ScanResults
 from opossum_lib.core.entities.source_info import SourceInfo
 from opossum_lib.input_formats.scancode.constants import SCANCODE_SOURCE_NAME
@@ -51,8 +52,8 @@ def _extract_scancode_header(scancode_data: ScancodeModel) -> HeaderModel:
 
 def _extract_opossum_resources(
     scancode_data: ScancodeModel,
-) -> TopLevelResource:
-    resources = TopLevelResource()
+) -> RootResource:
+    resources = RootResource()
     for file in scancode_data.files:
         resource = Resource(
             path=PurePath(file.path),

--- a/src/opossum_lib/input_formats/scancode/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/scancode/services/convert_to_opossum.py
@@ -12,7 +12,7 @@ from opossum_lib.core.entities.opossum import (
     Opossum,
 )
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, ResourceType
+from opossum_lib.core.entities.resource import Resource, ResourceType, TopLevelResource
 from opossum_lib.core.entities.scan_results import ScanResults
 from opossum_lib.core.entities.source_info import SourceInfo
 from opossum_lib.input_formats.scancode.constants import SCANCODE_SOURCE_NAME
@@ -51,17 +51,17 @@ def _extract_scancode_header(scancode_data: ScancodeModel) -> HeaderModel:
 
 def _extract_opossum_resources(
     scancode_data: ScancodeModel,
-) -> list[Resource]:
-    temp_root = Resource(path=PurePath(""))
+) -> TopLevelResource:
+    resources = TopLevelResource()
     for file in scancode_data.files:
         resource = Resource(
             path=PurePath(file.path),
             attributions=_get_attribution_info(file),
             type=_convert_resource_type(file.type),
         )
-        temp_root.add_resource(resource)
+        resources.add_resource(resource)
 
-    return list(temp_root.children.values())
+    return resources
 
 
 def _convert_resource_type(file_type: FileTypeModel) -> ResourceType:

--- a/tests/core/entities/generators/resource_provider.py
+++ b/tests/core/entities/generators/resource_provider.py
@@ -9,7 +9,8 @@ from faker.providers.file import Provider as FileProvider
 from faker.providers.misc import Provider as MiscProvider
 
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, ResourceType, TopLevelResource
+from opossum_lib.core.entities.resource import Resource, ResourceType
+from opossum_lib.core.entities.root_resource import RootResource
 from tests.core.entities.generators.package_provider import PackageProvider
 from tests.shared.generator_helpers import random_list
 
@@ -46,14 +47,11 @@ class ResourceProvider(BaseProvider):
 
     def resource_tree(
         self, max_depth: int = 4, max_files_per_level: int = 3, max_subfolders: int = 3
-    ) -> TopLevelResource:
+    ) -> RootResource:
         tree = self._sub_tree(
-            max_depth,
-            max_files_per_level,
-            max_subfolders,
-            current_path=PurePath(""),
+            max_depth, max_files_per_level, max_subfolders, current_path=PurePath("")
         )
-        return TopLevelResource(children=tree.children)
+        return RootResource(children=tree.children)
 
     def _sub_tree(
         self,

--- a/tests/core/entities/generators/resource_provider.py
+++ b/tests/core/entities/generators/resource_provider.py
@@ -9,7 +9,7 @@ from faker.providers.file import Provider as FileProvider
 from faker.providers.misc import Provider as MiscProvider
 
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, ResourceType
+from opossum_lib.core.entities.resource import Resource, ResourceType, TopLevelResource
 from tests.core.entities.generators.package_provider import PackageProvider
 from tests.shared.generator_helpers import random_list
 
@@ -46,12 +46,14 @@ class ResourceProvider(BaseProvider):
 
     def resource_tree(
         self, max_depth: int = 4, max_files_per_level: int = 3, max_subfolders: int = 3
-    ) -> Resource:
-        root_node = self._sub_tree(
-            max_depth, max_files_per_level, max_subfolders, current_path=PurePath("")
+    ) -> TopLevelResource:
+        tree = self._sub_tree(
+            max_depth,
+            max_files_per_level,
+            max_subfolders,
+            current_path=PurePath(""),
         )
-
-        return root_node
+        return TopLevelResource(children=tree.children)
 
     def _sub_tree(
         self,

--- a/tests/core/entities/generators/scan_results_provider.py
+++ b/tests/core/entities/generators/scan_results_provider.py
@@ -15,7 +15,8 @@ from opossum_lib.core.entities.external_attribution_source import (
 from opossum_lib.core.entities.frequent_license import FrequentLicense
 from opossum_lib.core.entities.metadata import Metadata
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, TopLevelResource
+from opossum_lib.core.entities.resource import Resource
+from opossum_lib.core.entities.root_resource import RootResource
 from opossum_lib.core.entities.scan_results import ScanResults
 from tests.core.entities.generators.external_attribution_source_provider import (
     ExternalAttributionSourceProvider,
@@ -53,7 +54,7 @@ class ScanResultsProvider(BaseProvider):
     def scan_results(
         self,
         metadata: Metadata | None = None,
-        resources: list[Resource] | TopLevelResource | None = None,
+        resources: list[Resource] | RootResource | None = None,
         attribution_breakpoints: list[str] | None = None,
         external_attribution_sources: dict[str, ExternalAttributionSource]
         | None = None,
@@ -66,7 +67,7 @@ class ScanResultsProvider(BaseProvider):
         if resources is None:
             generated_resources = self.resource_provider.resource_tree()
         elif isinstance(resources, list):
-            generated_resources = TopLevelResource()
+            generated_resources = RootResource()
             for resource in resources:
                 generated_resources.add_resource(resource)
         else:
@@ -111,7 +112,7 @@ class ScanResultsProvider(BaseProvider):
 
     def _attribution_to_id(
         self,
-        resources: TopLevelResource | None,
+        resources: RootResource | None,
         unassigned_attributions: set[OpossumPackage] | None,
     ) -> dict[OpossumPackage, str]:
         attributions = []

--- a/tests/core/entities/generators/scan_results_provider.py
+++ b/tests/core/entities/generators/scan_results_provider.py
@@ -15,7 +15,7 @@ from opossum_lib.core.entities.external_attribution_source import (
 from opossum_lib.core.entities.frequent_license import FrequentLicense
 from opossum_lib.core.entities.metadata import Metadata
 from opossum_lib.core.entities.opossum_package import OpossumPackage
-from opossum_lib.core.entities.resource import Resource, ResourceType
+from opossum_lib.core.entities.resource import Resource, TopLevelResource
 from opossum_lib.core.entities.scan_results import ScanResults
 from tests.core.entities.generators.external_attribution_source_provider import (
     ExternalAttributionSourceProvider,
@@ -53,7 +53,7 @@ class ScanResultsProvider(BaseProvider):
     def scan_results(
         self,
         metadata: Metadata | None = None,
-        resources: list[Resource] | None = None,
+        resources: list[Resource] | TopLevelResource | None = None,
         attribution_breakpoints: list[str] | None = None,
         external_attribution_sources: dict[str, ExternalAttributionSource]
         | None = None,
@@ -63,7 +63,14 @@ class ScanResultsProvider(BaseProvider):
         attribution_to_id: dict[OpossumPackage, str] | None = None,
         unassigned_attributions: set[OpossumPackage] | None = None,
     ) -> ScanResults:
-        generated_resources = resources or [self.resource_provider.resource_tree()]
+        if resources is None:
+            generated_resources = self.resource_provider.resource_tree()
+        elif isinstance(resources, list):
+            generated_resources = TopLevelResource()
+            for resource in resources:
+                generated_resources.add_resource(resource)
+        else:
+            generated_resources = resources
         generated_unassigned_attributions = unassigned_attributions or set()
         if unassigned_attributions is None:
             generated_unassigned_attributions = set(
@@ -104,25 +111,13 @@ class ScanResultsProvider(BaseProvider):
 
     def _attribution_to_id(
         self,
-        resources: list[Resource] | None,
+        resources: TopLevelResource | None,
         unassigned_attributions: set[OpossumPackage] | None,
     ) -> dict[OpossumPackage, str]:
         attributions = []
-
-        def get_attributions_from_resource_tree(
-            resource: Resource,
-        ) -> list[OpossumPackage]:
-            attributions: list[OpossumPackage] = resource.attributions
-            for child in resource.children.values():
-                if resource.type == ResourceType.FILE:
-                    attributions += child.attributions
-                else:
-                    attributions += get_attributions_from_resource_tree(child)
-            return attributions
-
         if resources:
-            for resource in resources:
-                attributions += get_attributions_from_resource_tree(resource)
+            for resource in resources.all_resources():
+                attributions += resource.attributions
 
         if unassigned_attributions:
             attributions += list(unassigned_attributions)

--- a/tests/core/entities/test_opossum.py
+++ b/tests/core/entities/test_opossum.py
@@ -39,6 +39,16 @@ class TestOpossumToOpossumModelConversion:
         expected_result_dict["scan_results"]["attribution_to_id"] = None
         result_dict["scan_results"]["attribution_to_id"] = None
 
+        # sort the lists again for comparability
+        expected_result_dict["scan_results"]["unassigned_attributions"] = sorted(
+            expected_result_dict["scan_results"]["unassigned_attributions"],
+            key=lambda x: x["source"]["name"],
+        )
+        result_dict["scan_results"]["unassigned_attributions"] = sorted(
+            result_dict["scan_results"]["unassigned_attributions"],
+            key=lambda x: x["source"]["name"],
+        )
+
         assert result_dict == expected_result_dict
 
     def test_roundtrip_with_preset_attribution_ids(

--- a/tests/core/services/test_merge_opossums.py
+++ b/tests/core/services/test_merge_opossums.py
@@ -230,16 +230,16 @@ class TestMergeOpossumsProducesCorrectContent:
 
         opossum1 = opossum_faker.opossum(
             generate_review_results=False,
-            scan_results=opossum_faker.scan_results(resources=[files1]),
+            scan_results=opossum_faker.scan_results(resources=files1),
         )
         opossum2 = opossum_faker.opossum(
             generate_review_results=False,
-            scan_results=opossum_faker.scan_results(resources=[files2]),
+            scan_results=opossum_faker.scan_results(resources=files2),
         )
 
         merged = merge_opossums([opossum1, opossum2])
         merged_file_tree = Resource(path=PurePath(""))
-        for resource in merged.scan_results.resources:
+        for resource in merged.scan_results.resources.all_resources():
             merged_file_tree.add_resource(resource)
 
         assert "folder" in merged_file_tree.children

--- a/tests/input_formats/scancode/services/test_convert_to_opossum.py
+++ b/tests/input_formats/scancode/services/test_convert_to_opossum.py
@@ -6,7 +6,6 @@
 import pytest
 from _pytest.logging import LogCaptureFixture
 
-from opossum_lib.core.entities.resource import Resource
 from opossum_lib.input_formats.scancode.services.convert_to_opossum import (
     convert_to_opossum,
 )
@@ -51,20 +50,6 @@ class TestExtractScancodeHeader:
 
 
 class TestConvertToOpossumFull:
-    @staticmethod
-    def _count_resources(resource: Resource) -> int:
-        return 1 + sum(
-            TestConvertToOpossumFull._count_resources(child)
-            for child in resource.children.values()
-        )
-
-    @staticmethod
-    def _count_attributions(resource: Resource) -> int:
-        return len(resource.attributions) + sum(
-            TestConvertToOpossumFull._count_attributions(child)
-            for child in resource.children.values()
-        )
-
     def test_convert(
         self,
         scancode_faker: ScanCodeFaker,
@@ -74,13 +59,12 @@ class TestConvertToOpossumFull:
 
         assert opossum_data.review_results is None
         scan_results = opossum_data.scan_results
-        assert sum(
-            TestConvertToOpossumFull._count_resources(res)
-            for res in scan_results.resources
-        ) == len(scancode_data.files)
+        assert len(list(scan_results.resources.all_resources())) == len(
+            scancode_data.files
+        )
         num_attributions = sum(
-            TestConvertToOpossumFull._count_attributions(res)
-            for res in scan_results.resources
+            len(resource.attributions)
+            for resource in scan_results.resources.all_resources()
         )
         num_license_detections = sum(
             len(f.license_detections) for f in scancode_data.files

--- a/tests/input_formats/scancode/services/test_get_attribution_info.py
+++ b/tests/input_formats/scancode/services/test_get_attribution_info.py
@@ -23,8 +23,10 @@ class TestGetAttributionInfo:
         folder = scancode_faker.single_folder(path="some/single/folder")
         scancode_data = scancode_faker.scancode_data(files=[folder])
         opossum = convert_to_opossum(scancode_data)
-        assert len(opossum.scan_results.resources) == 1
-        assert opossum.scan_results.resources[0].attributions == []
+        assert len(opossum.scan_results.resources.children) == 1
+        assert (
+            list(opossum.scan_results.resources.children.values())[0].attributions == []
+        )
 
     def test_get_attribution_info_from_file_without_detections(
         self,
@@ -35,8 +37,10 @@ class TestGetAttributionInfo:
         )
         scancode_data = scancode_faker.scancode_data(files=[file])
         opossum = convert_to_opossum(scancode_data)
-        assert len(opossum.scan_results.resources) == 1
-        assert opossum.scan_results.resources[0].attributions == []
+        assert len(opossum.scan_results.resources.children) == 1
+        assert (
+            list(opossum.scan_results.resources.children.values())[0].attributions == []
+        )
 
     def test_get_attribution_info_file_multiple(
         self, scancode_faker: ScanCodeFaker


### PR DESCRIPTION
## Summary of changes
This PR introduces `RootResource` as new model to replace `list[Resource]` as the type of `ScanResults.resources`.
This new model handles:
* insertion of new `Resources`
* iterating of all `Resources`

Thus it serves to simplify some reoccuring logic aorund the codebase:
* iteration replaces recursive function in `create_attribution_mapping`, `_merge_resources` and in `test_convert_to_opossum.py` (scancode)
* `temp_root` construct removed from `_extract_opossum_resources`, `_merge_resources`

Minor change:
* eliminated `_convert_path_to_str` in favor of `Path`'s `.as_posix()`


## Context and reason for change
During writing the `merge_opossums` I noticed that I started to repeat code that I had already written before. This PR aims to introduce an abstraction layer to clean that up. It is expected that this also helps future file frontends.

## How changes can be tested
There should be no functional difference.