### PR TITLE
Fix/precommit hooks broken

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@ repos:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.1
+    rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: [click == 8.1.3]
+        additional_dependencies: [click == 8.1.8, pydantic == 2.10.6]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     ":dependencyDashboard",
     ":automergeTypes",
     ":automergeLinters",
-    ":automergeTesters"
+    ":automergeTesters",
+    ":enablePreCommit"
   ],
   "addLabels": [
     "dependencies"


### PR DESCRIPTION
* The pre-commit hooks were broken due to 
   * missing dependency handling of mypy
   * outdated dependencies used
* This commit fixes these problems
* To avoid the problem of outdated dependencies in the future the precommit hooks have been included into renovate