### PR TITLE
fix: precommit mypy does not like the current faker setup

### DIFF
--- a/tests/setup/opossum_file_faker_setup.py
+++ b/tests/setup/opossum_file_faker_setup.py
@@ -55,5 +55,4 @@ def setup_opossum_file_faker(faker: Faker) -> OpossumFileFaker:
     faker.add_provider(OpossumOutputFileProvider)
     faker.add_provider(FileInformationProvider)
     faker.add_provider(MetadataProvider)
-    faker = cast(OpossumFileFaker, faker)
-    return faker
+    return cast(OpossumFileFaker, faker)

--- a/tests/setup/scancode_faker_setup.py
+++ b/tests/setup/scancode_faker_setup.py
@@ -34,5 +34,4 @@ class ScanCodeFaker(Faker):
 
 def setup_scancode_faker(faker: Faker) -> ScanCodeFaker:
     faker.add_provider(ScanCodeDataProvider)
-    faker = cast(ScanCodeFaker, faker)
-    return faker
+    return cast(ScanCodeFaker, faker)


### PR DESCRIPTION
Next commit after adding mypy to precommit fails even though `uv run python -m mypy src/ tests/` succeeds. This minor change fixes that.