### PR TITLE
feat: RootResource normalizes paths

### DIFF
--- a/src/opossum_lib/core/entities/root_resource.py
+++ b/src/opossum_lib/core/entities/root_resource.py
@@ -16,6 +16,10 @@ class RootResource(BaseModel):
     children: dict[str, Resource] = {}
 
     def add_resource(self, resource: Resource) -> None:
+        if resource.path.is_absolute():
+            # remove the root prefix to make the path relative, required by OpossumUI
+            path = PurePath(*resource.path.parts[1:])
+            resource = resource.model_copy(update={"path": path})
         remaining_path_parts = resource.path.parts
         if not remaining_path_parts:
             raise RuntimeError(f"Every resource needs a filepath. Got: {resource}")

--- a/src/opossum_lib/core/entities/scan_results.py
+++ b/src/opossum_lib/core/entities/scan_results.py
@@ -99,9 +99,8 @@ class ScanResults(BaseModel):
         ] = {}
 
         for resource in resources.all_resources():
-            path = resource.path.as_posix()
-            if not path.startswith("/"):
-                path = "/" + path
+            # OpossumUI always introduces an additional "/" as root
+            path = "/" + resource.path.as_posix()
             node_attributions_by_id = {
                 self._get_or_create_attribution_id(a): a.to_opossum_file_model()
                 for a in resource.attributions


### PR DESCRIPTION
## Summary of changes

* OpossumUI always assumes that the resources' paths are relative, i.e. there is no root folder named "/"
* Thus the RootResource enforces this when using `add_resource`

## Reason and context of the change
Opening a file produced by the OWASP converter in OpossumUI shows a weird file structure: There are 3 nested root folders, i.e. folders named `"/"` before the filetree begins and the attributions are not attached to their files. The root (pun intended) of this problem is that the paths from OWASP are given in absolute form, i.e. starting with "/". 
This PR fixes this problem once and for by enforcing a consistent normalization of paths done by the RootResource. Every `Resource` added to a `RootResource` by means of `add_resource` has its path stripped of any root. This guarantees that the resulting file will never look weird in OpossumUI and the attributions are always matched correctly.