### PR TITLE
Improvements of OWASP conversion

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: [click == 8.1.8, pydantic == 2.10.6]
+        additional_dependencies: [click == 8.1.8, pydantic == 2.10.6, faker>=36.1.1]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,13 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: [click == 8.1.8, pydantic == 2.10.6, faker>=36.1.1]
+        additional_dependencies: [
+          "click>=8.1.8,<9",
+          packageurl-python>=0.16.0,
+          pydantic == 2.10.6,
+          faker>=36.1.1,
+          "pytest>=8.3.4,<9"
+        ]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "A cli tool for handling Opossum files"
 requires-python = ">=3.13,<4"
 readme = "README.md"
 license = { file = "LICENSE" }
-dependencies = ["click>=8.1.8,<9", "packageurl-python>=0.16.0", "pydantic>=2.10.6", "pyinstaller>=6.12.0"]
+dependencies = ["click>=8.1.8,<9", "packageurl-python>=0.16.0", "pydantic>=2.10.6"]
 
 [project.urls]
 Repository = "https://github.com/opossum-tool/opossum-file"
@@ -28,6 +28,7 @@ dev = [
     "mdformat-gfm>=0.4.1",
     "reuse>=5.0.2",
     "taskipy>=1.14.1",
+    "pyinstaller>=6.12.0"
 ]
 
 [tool.uv]

--- a/src/opossum_lib/input_formats/owasp_dependency_scan/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/owasp_dependency_scan/services/convert_to_opossum.py
@@ -63,7 +63,7 @@ def _get_files_with_children(owasp_model: OWASPDependencyReportModel) -> list[st
     files_with_children = []
     for dependency in owasp_model.dependencies:
         if dependency.is_virtual:
-            str_path = str(dependency.file_path) + "/"
+            str_path = PurePath(dependency.file_path).as_posix() + "/"
             files_with_children.append(str_path)
     return files_with_children
 

--- a/src/opossum_lib/input_formats/owasp_dependency_scan/services/convert_to_opossum.py
+++ b/src/opossum_lib/input_formats/owasp_dependency_scan/services/convert_to_opossum.py
@@ -33,22 +33,20 @@ from opossum_lib.input_formats.owasp_dependency_scan.entities.owasp_dependency_r
 
 
 def convert_to_opossum(owasp_model: OWASPDependencyReportModel) -> Opossum:
-    resources, files_with_children = _extract_resources(owasp_model)
     return Opossum(
         scan_results=ScanResults(
             metadata=_extract_metadata(owasp_model),
             external_attribution_sources=_set_external_attribution_sources(),
-            resources=resources,
-            files_with_children=files_with_children,
+            resources=_extract_resources(owasp_model),
+            files_with_children=_get_files_with_children(owasp_model),
         )
     )
 
 
 def _extract_resources(
     owasp_model: OWASPDependencyReportModel,
-) -> tuple[RootResource, list[str]]:
+) -> RootResource:
     resources = RootResource()
-    files_with_children = []
     for dependency in owasp_model.dependencies:
         path = _extract_path(dependency)
         resource = Resource(
@@ -57,11 +55,17 @@ def _extract_resources(
             type=ResourceType.FILE,
         )
         resources.add_resource(resource)
+
+    return resources
+
+
+def _get_files_with_children(owasp_model: OWASPDependencyReportModel) -> list[str]:
+    files_with_children = []
+    for dependency in owasp_model.dependencies:
         if dependency.is_virtual:
             str_path = str(dependency.file_path) + "/"
             files_with_children.append(str_path)
-
-    return resources, files_with_children
+    return files_with_children
 
 
 def _extract_path(dependency: DependencyModel) -> PurePath:

--- a/tests/input_formats/owasp_dependency_scan/entities/generators/owasp_dependency_report_model_provider.py
+++ b/tests/input_formats/owasp_dependency_scan/entities/generators/owasp_dependency_report_model_provider.py
@@ -30,7 +30,12 @@ from opossum_lib.input_formats.owasp_dependency_scan.entities.owasp_dependency_r
     VulnerabilityIdModel,
     VulnerabilityModel,
 )
-from tests.shared.generator_helpers import entry_or_none, random_dict, random_list
+from tests.shared.generator_helpers import (
+    entry_or_none,
+    random_bool,
+    random_dict,
+    random_list,
+)
 
 
 class OWASPDependencyReportModelProvider(BaseProvider):
@@ -143,7 +148,7 @@ class OWASPDependencyReportModelProvider(BaseProvider):
         word_to_hash = self.lorem_provider.word().encode()
         generated_packages = self._generate_packages(packages)
         return DependencyModel(
-            is_virtual=is_virtual or self.misc_provider.boolean(),
+            is_virtual=random_bool(self.misc_provider, default=is_virtual),
             file_name=file_name or self.file_provider.file_name(),
             file_path=file_path or self.file_provider.file_path(depth=4),
             md5=md5 or self.misc_provider.md5(),

--- a/tests/input_formats/owasp_dependency_scan/services/test_convert_to_opossum.py
+++ b/tests/input_formats/owasp_dependency_scan/services/test_convert_to_opossum.py
@@ -170,7 +170,7 @@ class TestAttributionExtraction:
             dependencies=[
                 owasp_faker.dependency_model(
                     vulnerabilities=[vulnerability],
-                    packages=[owasp_faker.package_model()],
+                    packages=owasp_faker.package_models(min_nb_of_packages=1),
                 )
             ]
         )
@@ -192,7 +192,7 @@ class TestAttributionExtraction:
             dependencies=[
                 owasp_faker.dependency_model(
                     vulnerabilities=[],
-                    packages=[owasp_faker.package_model()],
+                    packages=owasp_faker.package_models(min_nb_of_packages=1),
                 )
             ]
         )
@@ -212,7 +212,7 @@ class TestAttributionExtraction:
             dependencies=[
                 owasp_faker.dependency_model(
                     license=license_text,
-                    packages=[owasp_faker.package_model()],
+                    packages=owasp_faker.package_models(min_nb_of_packages=1),
                 )
             ]
         )

--- a/tests/input_formats/owasp_dependency_scan/services/test_convert_to_opossum.py
+++ b/tests/input_formats/owasp_dependency_scan/services/test_convert_to_opossum.py
@@ -57,8 +57,11 @@ class TestConvertMetadata:
 
 class TestAttributionExtraction:
     def test_extracts_basic_attribution(self, owasp_faker: OwaspFaker) -> None:
+        valid_dependency = owasp_faker.dependency_model(
+            packages=owasp_faker.package_models(min_nb_of_packages=1),
+        )
         owasp_model = owasp_faker.owasp_dependency_report_model(
-            dependencies=owasp_faker.dependencies(min_number_of_dependencies=1)
+            dependencies=owasp_faker.dependencies() + [valid_dependency]
         )
 
         opossum: Opossum = convert_to_opossum(owasp_model)

--- a/tests/shared/generator_helpers.py
+++ b/tests/shared/generator_helpers.py
@@ -40,3 +40,12 @@ def random_dict(
 ) -> dict[T, Q]:
     number_of_entries = faker.random_int(min_number_of_entries, max_number_of_entries)
     return {key_generator(): entry_generator() for _ in range(number_of_entries)}
+
+
+def random_bool(
+    misc_provider: MiscProvider, default: bool | None, chance_of_getting_true: int = 50
+) -> bool:
+    if default is None:
+        return misc_provider.boolean(chance_of_getting_true=chance_of_getting_true)
+    else:
+        return default

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.13, <4"
 
 [[package]]
@@ -381,7 +380,6 @@ dependencies = [
     { name = "click" },
     { name = "packageurl-python" },
     { name = "pydantic" },
-    { name = "pyinstaller" },
 ]
 
 [package.dev-dependencies]
@@ -392,6 +390,7 @@ dev = [
     { name = "mdformat-gfm" },
     { name = "mypy" },
     { name = "pre-commit" },
+    { name = "pyinstaller" },
     { name = "reuse" },
     { name = "ruff" },
     { name = "taskipy" },
@@ -406,7 +405,6 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.8,<9" },
     { name = "packageurl-python", specifier = ">=0.16.0" },
     { name = "pydantic", specifier = ">=2.10.6" },
-    { name = "pyinstaller", specifier = ">=6.12.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -417,6 +415,7 @@ dev = [
     { name = "mdformat-gfm", specifier = ">=0.4.1" },
     { name = "mypy", specifier = ">=1.15.0" },
     { name = "pre-commit", specifier = ">=4.1.0" },
+    { name = "pyinstaller", specifier = ">=6.12.0" },
     { name = "reuse", specifier = ">=5.0.2" },
     { name = "ruff", specifier = ">=0.9.6" },
     { name = "taskipy", specifier = ">=1.14.1" },


### PR DESCRIPTION
* Correctly set path dependent on whether a dependency is virtual or not
* No longer add attributions if there are neither packages nor evidences
* Add all virtual dependencies to the files with children