### PR TITLE
Add mypy precommit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,13 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
-        additional_dependencies: [click == 8.1.8, pydantic == 2.10.6, faker>=36.1.1]
+        additional_dependencies: [
+          "click>=8.1.8,<9",
+          packageurl-python>=0.16.0,
+          pydantic == 2.10.6,
+          faker>=36.1.1,
+          "pytest>=8.3.4,<9"
+        ]
   - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:


### PR DESCRIPTION
Add the dependencies from the `project.toml` also to the `pre-commit-config.yaml`.

Goal: Make mypy behavior of precommit scans and cli runs the same

Context: Pre-commit mypy runs in a dedicated venv which by default does not get the project's dependencies. This leads to differing behavior between the pre-commit hook and the cli runs

Possible caveat: We now need to maintain the dependencies at two places. However, this should be taken care of by renovate